### PR TITLE
Filter products by min_price

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -249,6 +249,7 @@ class Products(ViewSet):
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
         location = self.request.query_params.get('location', None)
+        min_price = self.request.query_params.get('min_price', None )
 
         if order is not None:
             order_filter = order
@@ -264,6 +265,9 @@ class Products(ViewSet):
 
         if quantity is not None:
             products = products.order_by("-created_date")[:int(quantity)]
+        
+        if min_price is not None:
+            products = products.filter(price__gt=min_price)
         
         if location is not None:
             products = products.filter(location__contains=location)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Added `min_price` filter to products

## Requests / Responses


**Request**

GET `/products?min_price="int"` Gets all products that are greater than int

**Response**

HTTP/1.1 201 OK


## Testing

Description of how to test code...

- [ ] run server
- [ ] run Get request `http://localhost:8000/products?min_price=1500`
- [ ] verify that all products have a min price of 1500


## Related Issues
