### PR TITLE
Line Items can be deleted by number

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -36,17 +36,17 @@ class LineItems(ViewSet):
 
     def retrieve(self, request, pk=None):
         """
-        @api {GET} /cart/:id DELETE line item from cart
-        @apiName RemoveLineItem
+        @api {GET} /lineitems/:id DELETE line item from cart
+        @apiName GetLineItem
         @apiGroup ShoppingCart
 
         @apiHeader {String} Authorization Auth token
         @apiHeaderExample {String} Authorization
             Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        @apiParam {id} id Product Id to remove from cart
+        @apiParam {id} id LineItem (order product) Id to get from cart
         @apiSuccessExample {json} Success
-            HTTP/1.1 204 No Content
+            HTTP/1.1 200 OK
         """
         try:
             # line_item = OrderProduct.objects.get(pk=pk)
@@ -62,7 +62,7 @@ class LineItems(ViewSet):
 
     def destroy(self, request, pk=None):
         """
-        @api {DELETE} /cart/:id DELETE line item from cart
+        @api {DELETE} /LineItems/:id DELETE line item from cart
         @apiName RemoveLineItem
         @apiGroup ShoppingCart
 
@@ -70,13 +70,15 @@ class LineItems(ViewSet):
         @apiHeaderExample {String} Authorization
             Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        @apiParam {id} id Product Id to remove from cart
+        @apiParam {id} id LineItem (order product) Id to remove from cart
         @apiSuccessExample {json} Success
-            HTTP/1.1 204 No Content
+            HTTP/1.1 200 OK
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Changed retrieval requests and response to Line Items instead of Cart
- Changed delete requests and response to Line items instead of Cart

## Requests / Responses


**Request**

DELETE `/lineitems/5` Creates a new product

```json
{
    "id": 5,
    "url": "http://localhost:8000/lineitems/5",
    "order": "http://localhost:8000/orders/2",
    "product": "http://localhost:8000/products/33"
}
```

**Response**

HTTP/1.1 204 NO CONTENT



## Testing

Description of how to test code...

- [ ] python manage.py runserver
- [ ] Run Postman
- [ ] Run DELETE `http://localhost:8000/lineitems/5`
- [ ] Should get 204


## Related Issues

- Fixes #18 